### PR TITLE
ホバーした線の強調表示を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "maplibre-gl": "^4.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-map-gl": "^7.1.7"
+    "react-map-gl": "^7.1.7",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   react-map-gl:
     specifier: ^7.1.7
     version: 7.1.7(maplibre-gl@4.1.2)(react-dom@18.2.0)(react@18.2.0)
+  zustand:
+    specifier: ^4.5.2
+    version: 4.5.2(@types/react@18.2.75)(react@18.2.0)
 
 devDependencies:
   '@types/react':
@@ -1392,7 +1395,6 @@ packages:
 
   /@types/prop-types@15.7.12:
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
-    dev: true
 
   /@types/react-dom@18.2.24:
     resolution: {integrity: sha512-cN6upcKd8zkGy4HU9F1+/s98Hrp6D4MOcippK4PoE8OZRngohHZpbJn1GsaDLz87MqvHNoT13nHvNqM9ocRHZg==}
@@ -1405,7 +1407,6 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
-    dev: true
 
   /@types/semver@7.5.8:
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -1749,7 +1750,6 @@ packages:
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-    dev: true
 
   /d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -3005,6 +3005,14 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /use-sync-external-store@1.2.0(react@18.2.0):
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: false
@@ -3085,3 +3093,23 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /zustand@4.5.2(@types/react@18.2.75)(react@18.2.0):
+    resolution: {integrity: sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@types/react': 18.2.75
+      react: 18.2.0
+      use-sync-external-store: 1.2.0(react@18.2.0)
+    dev: false

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,9 +1,41 @@
 import Map, { GeolocateControl, NavigationControl, ScaleControl, useControl } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { DeckProps } from '@deck.gl/core';
+import { DeckProps, PickingInfo } from '@deck.gl/core';
 import { MapboxOverlay } from '@deck.gl/mapbox';
-import { getTooltip, layerFromRouteData } from '../data/data';
+import { RouteData, keyFromData, layerFromRouteData, pathLayerFromData } from '../data/data';
 import './App.css';
+import { useEffect, useMemo, useState } from 'react';
+import { useAppState } from '../misc/store';
+import { isSmartphone } from '../misc/util';
+import { PathLayer } from '@deck.gl/layers';
+
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+/**
+ * PCで適用するスタイル。
+ * マウスカーソルの位置に応じて表示する。
+ */
+const PC_STYLE: Partial<CSSStyleDeclaration> = {
+  borderRadius: '8px',
+  maxWidth: '18rem',
+  background: 'hsla(200, 20%, 10%, 0.8)',
+  padding: '0.3rem 0.8rem 0.4rem',
+  left: '-4rem',
+};
+
+/**
+ * スマートフォンで適用するスタイル。
+ * 画面上部中央に表示する。
+ */
+const SP_STYLE: Partial<CSSStyleDeclaration> = {
+  borderRadius: '8px',
+  background: 'hsla(200, 20%, 10%, 0.8)',
+  padding: '0.3rem 0.8rem 0.4rem',
+  transform: 'translate(0, 0)',
+  top: '1rem',
+  left: '10%',
+  marginRight: '15%',
+};
 
 /**
  * MapLibre のコントロールを有効化するためのオーバーレイ
@@ -12,12 +44,46 @@ import './App.css';
  * @see https://deck.gl/docs/api-reference/mapbox/mapbox-overlay
  */
 function DeckGLOverlay(props: DeckProps) {
+  const setSelected = useAppState((st) => st.setSelected);
+
+  /**
+   * ツールチップを生成する。
+   * className でスタイルを与えても padding だけは反映されなかったため、スタイルを直書き。
+   */
+  function getTooltip({ object }: PickingInfo) {
+    if (!object) {
+      return null;
+    }
+
+    if (object.kind === 'route-data') {
+      const data = object as RouteData;
+      const str = `${'★'.repeat(data.gravel)}<br /><b>${data.name}</b><br />${data.description}`;
+      setSelected(keyFromData(data));
+      // className で指定しても display と transform はデフォルトが優先されるので、 style として指定。
+      // @see https://github.com/visgl/deck.gl/blob/fa029dddebc43f350cef07cf8e9fe86d98415c02/modules/core/src/lib/tooltip.ts#L93
+      return {
+        html: str,
+        style: isSmartphone() ? SP_STYLE : PC_STYLE,
+      };
+    }
+    return null; //JSON.stringify(object);
+  }
+
+  const data = useAppState((st) => st.data);
+  const layer = useMemo(() => pathLayerFromData(data), [data]);
+  // console.log(data);
+
   const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
-  overlay.setProps(props);
+  overlay.setProps({ ...props, getTooltip, layers: [layer] });
   return null;
 }
 
 export function App() {
+  // const [flag, setFlag] = useState(false);
+  // useEffect(() => {
+  //   setFlag(updateFlag);
+  // }, [updateFlag]);
+
   return (
     <div style={{ width: '100dvw', height: '100dvh', position: 'absolute', left: 0, top: 0 }}>
       <Map
@@ -32,7 +98,10 @@ export function App() {
         <NavigationControl />
         <GeolocateControl />
         <ScaleControl />
-        <DeckGLOverlay layers={[layerFromRouteData()]} getTooltip={getTooltip} pickingRadius={8} />
+        <DeckGLOverlay
+          //  layers={[layerFromRouteData()]}
+          pickingRadius={8}
+        />
       </Map>
     </div>
   );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -37,6 +37,8 @@ const SP_STYLE: Partial<CSSStyleDeclaration> = {
   marginRight: '15%',
 };
 
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
 /**
  * MapLibre のコントロールを有効化するためのオーバーレイ
  *
@@ -44,7 +46,8 @@ const SP_STYLE: Partial<CSSStyleDeclaration> = {
  * @see https://deck.gl/docs/api-reference/mapbox/mapbox-overlay
  */
 function DeckGLOverlay(props: DeckProps) {
-  const setSelected = useAppState((st) => st.setSelected);
+  // const setSelected = useAppState((st) => st.setSelected);
+  const [selectedData, setSelectedData] = useAppState((st) => [st.selectedData, st.setSelectedData]);
 
   /**
    * ツールチップを生成する。
@@ -58,7 +61,8 @@ function DeckGLOverlay(props: DeckProps) {
     if (object.kind === 'route-data') {
       const data = object as RouteData;
       const str = `${'★'.repeat(data.gravel)}<br /><b>${data.name}</b><br />${data.description}`;
-      setSelected(keyFromData(data));
+      setSelectedData(data);
+
       // className で指定しても display と transform はデフォルトが優先されるので、 style として指定。
       // @see https://github.com/visgl/deck.gl/blob/fa029dddebc43f350cef07cf8e9fe86d98415c02/modules/core/src/lib/tooltip.ts#L93
       return {
@@ -70,11 +74,12 @@ function DeckGLOverlay(props: DeckProps) {
   }
 
   const data = useAppState((st) => st.data);
-  const layer = useMemo(() => pathLayerFromData(data), [data]);
-  // console.log(data);
+  const mainLayer = useMemo(() => pathLayerFromData(data), [data]);
+
+  const selectedLayer = selectedData ? pathLayerFromData(selectedData, true) : null;
 
   const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
-  overlay.setProps({ ...props, getTooltip, layers: [layer] });
+  overlay.setProps({ ...props, getTooltip, layers: [mainLayer, selectedLayer] });
   return null;
 }
 

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -1,35 +1,36 @@
 import { PathLayer } from '@deck.gl/layers';
-import type { PickingInfo } from '@deck.gl/core';
 
-import FILE from './data.json';
 import { colorFromGravelLevel } from './constants';
-import { isSmartphone } from '../misc/util';
-import { useAppState } from '../misc/store';
-
-// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+import FILE from './data.json';
 
 // -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
 /**
  * ファイルのデータを元に、レイヤーを生成する。
  */
-export function layerFromRouteData(): PathLayer {
-  return new PathLayer<RouteData>({
-    id: 'route-path',
-    data: routeDataFromFile(),
-    getColor: (d) => colorFromGravelLevel(d.gravel),
-    getPath: (d: RouteData) => {
-      return d.coordinates;
-    },
-    getWidth: (d) => (d.isSelected ? 500 : 10),
-    widthUnits: 'meters',
-    widthMinPixels: 4,
-    pickable: true,
-    capRounded: true,
-    jointRounded: true,
-  });
-}
+// export function layerFromRouteData(): PathLayer {
+//   return new PathLayer<RouteData>({
+//     id: 'route-path',
+//     data: routeDataFromFile(),
+//     getColor: (d) => colorFromGravelLevel(d.gravel),
+//     getPath: (d: RouteData) => {
+//       return d.coordinates;
+//     },
+//     getWidth: (d) => (d.isSelected ? 500 : 10),
+//     widthUnits: 'meters',
+//     widthMinPixels: 4,
+//     pickable: true,
+//     capRounded: true,
+//     jointRounded: true,
+//   });
+// }
 
+/**
+ * 渡されたデータを元に PathLayer を生成する。
+ * @param data ルートデータ。配列 or 1つ。
+ * @param isSelected 選択状態かどうかのフラグ。選択されていると太く表示する。
+ * @returns PathLayer
+ */
 export function pathLayerFromData(data: RouteData | RouteData[], isSelected: boolean = false) {
   return new PathLayer<RouteData>({
     id: 'route-path',
@@ -126,9 +127,20 @@ export function routeDataFromFile(): RouteData[] {
   return list;
 }
 
+/**
+ * ルートデータのキーを生成する
+ */
 export function keyFromData(data: RouteData): string {
-  return `${data.name}-${data.coordinates[0][0]}`;
+  // データは 経度-緯度 の順
+  return `${data.name}-${data.coordinates[0][1]}`;
 }
+
+/**
+ * ルートデータのキーを、ファイルから読み取ったデータを元に生成する。
+ * データ読込時のみに使用する。
+ * 生成されるキーを `keyFromData()` と合わせる必要がある。
+ */
 function keyFromFileRoute(data: FileRoute): string {
-  return `${data.name}-${data.cods[0][1]}`;
+  // ファイルの中身は 緯度-経度 の順
+  return `${data.name}-${data.cods[0][0]}`;
 }

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -30,17 +30,17 @@ export function layerFromRouteData(): PathLayer {
   });
 }
 
-export function pathLayerFromData(data: RouteData[]) {
+export function pathLayerFromData(data: RouteData | RouteData[], isSelected: boolean = false) {
   return new PathLayer<RouteData>({
     id: 'route-path',
-    data: data,
+    data: Array.isArray(data) ? data : [data],
     getColor: (d) => colorFromGravelLevel(d.gravel),
     getPath: (d: RouteData) => {
       return d.coordinates;
     },
-    getWidth: (d) => (d.isSelected ? 500 : 10),
+    getWidth: isSelected ? 40 : 10,
     widthUnits: 'meters',
-    widthMinPixels: 4,
+    widthMinPixels: isSelected ? 8 : 4,
     pickable: true,
     capRounded: true,
     jointRounded: true,

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -4,57 +4,9 @@ import type { PickingInfo } from '@deck.gl/core';
 import FILE from './data.json';
 import { colorFromGravelLevel } from './constants';
 import { isSmartphone } from '../misc/util';
+import { useAppState } from '../misc/store';
 
 // -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
-
-/**
- * PCで適用するスタイル。
- * マウスカーソルの位置に応じて表示する。
- */
-const PC_STYLE: Partial<CSSStyleDeclaration> = {
-  borderRadius: '8px',
-  maxWidth: '18rem',
-  background: 'hsla(200, 20%, 10%, 0.8)',
-  padding: '0.3rem 0.8rem 0.4rem',
-  left: '-4rem',
-};
-
-/**
- * スマートフォンで適用するスタイル。
- * 画面上部中央に表示する。
- */
-const SP_STYLE: Partial<CSSStyleDeclaration> = {
-  borderRadius: '8px',
-  background: 'hsla(200, 20%, 10%, 0.8)',
-  padding: '0.3rem 0.8rem 0.4rem',
-  transform: 'translate(0, 0)',
-  top: '1rem',
-  left: '10%',
-  marginRight: '15%',
-};
-
-// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
-
-/**
- * ツールチップを生成する。
- * className でスタイルを与えても padding だけは反映されなかったため、スタイルを直書き。
- */
-export function getTooltip({ object }: PickingInfo) {
-  if (!object) {
-    return null;
-  }
-  if (object.kind === 'route-data') {
-    const data = object as RouteData;
-    const str = `${'★'.repeat(data.gravel)}<br /><b>${data.name}</b><br />${data.description}`;
-    // className で指定しても display と transform はデフォルトが優先されるので、 style として指定。
-    // @see https://github.com/visgl/deck.gl/blob/fa029dddebc43f350cef07cf8e9fe86d98415c02/modules/core/src/lib/tooltip.ts#L93
-    return {
-      html: str,
-      style: isSmartphone() ? SP_STYLE : PC_STYLE,
-    };
-  }
-  return JSON.stringify(object);
-}
 
 // -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
@@ -69,7 +21,24 @@ export function layerFromRouteData(): PathLayer {
     getPath: (d: RouteData) => {
       return d.coordinates;
     },
-    getWidth: 10,
+    getWidth: (d) => (d.isSelected ? 500 : 10),
+    widthUnits: 'meters',
+    widthMinPixels: 4,
+    pickable: true,
+    capRounded: true,
+    jointRounded: true,
+  });
+}
+
+export function pathLayerFromData(data: RouteData[]) {
+  return new PathLayer<RouteData>({
+    id: 'route-path',
+    data: data,
+    getColor: (d) => colorFromGravelLevel(d.gravel),
+    getPath: (d: RouteData) => {
+      return d.coordinates;
+    },
+    getWidth: (d) => (d.isSelected ? 500 : 10),
     widthUnits: 'meters',
     widthMinPixels: 4,
     pickable: true,
@@ -95,10 +64,11 @@ type FileRoute = {
 /**
  * ルートデータの型
  */
-type RouteData = {
+export type RouteData = {
   kind: 'route-data';
   /** 名前 */
   name: string;
+  key: string;
   /** グラベルレベル */
   gravel: number;
   /** 道幅レベル */
@@ -109,6 +79,7 @@ type RouteData = {
   description: string;
   /** 座標の並び */
   coordinates: [number, number][];
+  isSelected: boolean;
 };
 
 /**
@@ -127,19 +98,21 @@ function parseRouteData(source: FileRoute): RouteData | undefined {
 
   return {
     kind: 'route-data',
+    key: keyFromFileRoute(source),
     name: source.name,
     gravel: source.gra,
     width: source.wid,
     slope: source.slp,
     description: source.desc,
     coordinates,
+    isSelected: false,
   };
 }
 
 /**
  * ファイルの情報を元に、ルートデータを生成する
  */
-function routeDataFromFile(): RouteData[] {
+export function routeDataFromFile(): RouteData[] {
   const list = [];
 
   for (const r of FILE.routes) {
@@ -151,4 +124,11 @@ function routeDataFromFile(): RouteData[] {
   }
 
   return list;
+}
+
+export function keyFromData(data: RouteData): string {
+  return `${data.name}-${data.coordinates[0][0]}`;
+}
+function keyFromFileRoute(data: FileRoute): string {
+  return `${data.name}-${data.cods[0][1]}`;
 }

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -80,7 +80,6 @@ export type RouteData = {
   description: string;
   /** 座標の並び */
   coordinates: [number, number][];
-  isSelected: boolean;
 };
 
 /**
@@ -106,7 +105,6 @@ function parseRouteData(source: FileRoute): RouteData | undefined {
     slope: source.slp,
     description: source.desc,
     coordinates,
-    isSelected: false,
   };
 }
 

--- a/src/misc/store.ts
+++ b/src/misc/store.ts
@@ -4,7 +4,9 @@ import { RouteData, routeDataFromFile } from '../data/data';
 type AppState = {
   data: RouteData[];
   setData: (data: RouteData[]) => void;
-  setSelected: (key: string) => void;
+  // setSelected: (key: string) => void;
+  selectedData: RouteData | undefined;
+  setSelectedData: (data: RouteData) => void;
 };
 
 export const useAppState = create<AppState>((set, get) => ({
@@ -12,14 +14,18 @@ export const useAppState = create<AppState>((set, get) => ({
   setData(data) {
     set({ data });
   },
-  setSelected(key) {
-    const array = [];
-    for (const d of get().data) {
-      if (d.key === key) {
-        d.width = 500;
-      }
-      array.push(d);
-    }
-    set({ data: array });
+  // setSelected(key) {
+  //   const array = [];
+  //   for (const d of get().data) {
+  //     if (d.key === key) {
+  //       d.width = 500;
+  //     }
+  //     array.push(d);
+  //   }
+  //   set({ data: array });
+  // },
+  selectedData: undefined,
+  setSelectedData(data) {
+    set({ selectedData: data });
   },
 }));

--- a/src/misc/store.ts
+++ b/src/misc/store.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import { RouteData, routeDataFromFile } from '../data/data';
+
+type AppState = {
+  data: RouteData[];
+  setData: (data: RouteData[]) => void;
+  setSelected: (key: string) => void;
+};
+
+export const useAppState = create<AppState>((set, get) => ({
+  data: routeDataFromFile(),
+  setData(data) {
+    set({ data });
+  },
+  setSelected(key) {
+    const array = [];
+    for (const d of get().data) {
+      if (d.key === key) {
+        d.width = 500;
+      }
+      array.push(d);
+    }
+    set({ data: array });
+  },
+}));

--- a/src/misc/store.ts
+++ b/src/misc/store.ts
@@ -2,29 +2,34 @@ import { create } from 'zustand';
 import { RouteData, routeDataFromFile } from '../data/data';
 
 type AppState = {
+  /**
+   * アプリで使用するルートデータの配列
+   */
   data: RouteData[];
+  /**
+   * アプリで使用するルートデータの配列を設定する
+   */
   setData: (data: RouteData[]) => void;
-  // setSelected: (key: string) => void;
+  /**
+   * 選択されているルートデータ
+   * ここに登録されているルートは太く表示される
+   */
   selectedData: RouteData | undefined;
+  /**
+   * 選択されているルートデータを設定する
+   */
   setSelectedData: (data: RouteData) => void;
 };
 
-export const useAppState = create<AppState>((set, get) => ({
+export const useAppState = create<AppState>((set) => ({
   data: routeDataFromFile(),
+
   setData(data) {
     set({ data });
   },
-  // setSelected(key) {
-  //   const array = [];
-  //   for (const d of get().data) {
-  //     if (d.key === key) {
-  //       d.width = 500;
-  //     }
-  //     array.push(d);
-  //   }
-  //   set({ data: array });
-  // },
+
   selectedData: undefined,
+
   setSelectedData(data) {
     set({ selectedData: data });
   },


### PR DESCRIPTION
マウスカーソルをホバー（スマートフォンの場合はタップ）した線について、ツールチップを表示する（既存実装）とともに、線を太くして強調表示する機能を実装した。

既存データの幅を変更したときに表示を更新する方法が分からなかったため、太い線を別途用意して描画する処理とした。いずれにしても、今の実装の方が更新データ量が少なくて速いものと思われる。

メモ化していないが、それほど重くない処理であるため、問題ないと想定している。